### PR TITLE
IDA 7 support & GUID Class Bugfix

### DIFF
--- a/core/objects/guid.py
+++ b/core/objects/guid.py
@@ -16,9 +16,9 @@ class GUID:
             self.__ptr = ptr
         else:
             raise ValueError()
-        if self.__ptr.type != this.IDA_TYPE:
+        if self.__ptr.type != GUID.IDA_TYPE:
             MakeUnknown(self.__ptr.addr, 16, DOUNK_SIMPLE)
-            self.__ptr.type = Structure(this.IDA_TYPE).name
+            self.__ptr.type = Structure(GUID.IDA_TYPE).name
 
     @property
     def name(self):

--- a/core/objects/instruction.py
+++ b/core/objects/instruction.py
@@ -152,7 +152,7 @@ class _OperandType:
     def __cmp__(self, other):
         if isinstance(other, _OperandType):
             return cmp(self.__op_type, other.__op_type)
-        elif type(other) is int:
+        elif type(other) in (int, long):
             return cmp(self.__op_type, other)
         raise NotImplementedError
 

--- a/tools/structures.py
+++ b/tools/structures.py
@@ -1,4 +1,5 @@
 from idaapi import *
+import idautils
 from idautils import *
 from idc import *
 
@@ -81,7 +82,12 @@ def _update_structs_from_track(track):
                     isinstance(track[op.reg], Structure):
                 if track[op.reg].dummy:
                     _guess_struct_field(item, op, track[op.reg])
-                OpStroff(item.ea, op.n, track[op.reg].sid)
+
+                if IDA_SDK_VERSION >= 700:
+                    ins = idautils.DecodeInstruction(item.ea)
+                else:
+                    ins = item.ea
+                OpStroff(ins, op.n, track[op.reg].sid)
 
         for obj, state in track.items():
 


### PR DESCRIPTION
- Added IDA 7 support
- Fixed bug in GUID class which made this tool unusable. The bug was using 'this' rather than 'self' to access a class member. As the member is a static class member, I rewrote it as 'GUID.'.